### PR TITLE
Specify strategy for python3

### DIFF
--- a/.github/workflows/webpmigrator.yml
+++ b/.github/workflows/webpmigrator.yml
@@ -13,16 +13,16 @@ on:
 jobs:
   Convert-to-WEBP:
     runs-on: ubuntu-latest
-    #strategy: # Proper way to prepare which python to use
-    #  matrix:
-    #    python-version: [3]
+    strategy: # Proper way to prepare which python to use
+      matrix:
+        python-version: [3]
     env:
       WEBPCONVERTERARGS: --r -q=100 # These are args, --r is required, q is quality
     steps:
-      #- name: Set up Python ${{ matrix.python-version }}
-      #  uses: actions/setup-python@v2
-      #  with:
-      #    python-version: ${{ matrix.python-version }} # Adept to strategy to use python3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }} # Adept to strategy to use python3
       - name: Install dependencies
         run: | # We install webp and then the webp-converter
           sudo apt install webp -y


### PR DESCRIPTION
Hopefully fixes 

Failed:

Collecting webp-converter
  Downloading https://files.pythonhosted.org/packages/fc/cf/da77b6c4640ffdddb7beafcfce27ffd40494acab794bb8d6e7a6473ecea6/webp-converter-4.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-oh2xsv3z/webp-converter/
Error: Process completed with exit code 1.